### PR TITLE
A simple way to test the ExtensionProcessor

### DIFF
--- a/annotations-processor/build.gradle
+++ b/annotations-processor/build.gradle
@@ -14,7 +14,6 @@
  *  You should have received a copy of the GNU General Public License
  *   along with Block IDLE.  If not, see <https://www.gnu.org/licenses/>.
  */
-
 plugins {
 	id("java")
 }
@@ -25,7 +24,19 @@ java {
 }
 
 dependencies {
+	// Add your annotation processor module as an implementation dependency
 	implementation project(":annotations")
+
+	// Add Google Compile Testing for testing annotation processors
+	implementation 'com.google.testing.compile:compile-testing:0.19'
+
+	// Add JUnit 5 for running tests
+	implementation 'org.junit.jupiter:junit-jupiter:5.9.3'
+
+	// Optional: Add Mockito if you need to mock objects in tests
+	implementation 'org.mockito:mockito-core:5.2.0'
+
+	implementation 'com.google.truth:truth:1.1.5'
 }
 
 sourceSets {
@@ -37,4 +48,9 @@ sourceSets {
 			srcDirs = ["src/main/resources"]
 		}
 	}
+}
+
+test {
+	// Use JUnit Platform (JUnit 5) for running tests
+	useJUnitPlatform()
 }

--- a/annotations-processor/src/main/java/com/icst/blockidle/ExtensionProcessorTester.java
+++ b/annotations-processor/src/main/java/com/icst/blockidle/ExtensionProcessorTester.java
@@ -1,0 +1,197 @@
+/*
+ *  This file is part of Block IDLE.
+ *
+ *  Block IDLE is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  Block IDLE is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *   along with Block IDLE.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+package com.icst.blockidle;
+
+import com.google.testing.compile.*;
+import com.google.testing.compile.Compiler;
+import org.junit.Test;
+
+import java.io.File;
+
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static org.junit.Assert.fail;
+
+public class extensionProcessorTester {
+
+
+
+    @Test
+    public void testInvalidAnnotationUsage() {
+        //the class doesn't have the @Extension annotation
+        String sourceCode1 = """
+            package test;
+
+            import com.icst.blockidle.Extension;
+            import com.icst.blockidle.ExtensionItem;
+            import java.io.Serializable;
+
+            public class MyTestClass {
+               @ExtensionItem(extensionItemName = "")
+               public static String myValidMethod() {
+                   return "TestValue";
+            }
+        }
+        """;
+
+        //the method has parameters
+        String sourceCode2 = """
+            package test;
+
+            import com.icst.blockidle.Extension;
+            import com.icst.blockidle.ExtensionItem;
+            import java.io.Serializable;
+
+            @Extension(extensionFileName = "")
+            public class MyTestClass {
+               @ExtensionItem(extensionItemName = "")
+               public static String myValidMethod(String param) {
+                   System.out.println(param);
+                   return "TestValue";
+            }
+        }
+        """;
+
+        //the method is not public
+        String sourceCode3 = """
+            package test;
+
+            import com.icst.blockidle.Extension;
+            import com.icst.blockidle.ExtensionItem;
+            import java.io.Serializable;
+
+            @Extension(extensionFileName = "")
+            private class MyTestClass {
+               @ExtensionItem(extensionItemName = "")
+               public static String myValidMethod() {
+                   return "TestValue";
+            }
+        }
+        """;
+
+        //the method has bad return type/doesn't return anything
+        String sourceCode4 = """
+            package test;
+
+            import com.icst.blockidle.Extension;
+            import com.icst.blockidle.ExtensionItem;
+            import java.io.Serializable;
+
+            @Extension(extensionFileName = "")
+            public class MyTestClass {
+               @ExtensionItem(extensionItemName = "")
+               public static void myValidMethod() {
+               System.out.println("something");
+            }
+        }
+        """;
+
+        //the method is not static
+        String sourceCode5 = """
+            package test;
+
+            import com.icst.blockidle.Extension;
+            import com.icst.blockidle.ExtensionItem;
+            import java.io.Serializable;
+
+            @Extension(extensionFileName = "")
+            public class MyTestClass {
+               @ExtensionItem(extensionItemName = "")
+               public String myValidMethod() {
+                   return "TestValue";
+            }
+        }
+        """;
+
+
+        Compilation compilationNoAnnotation = Compiler.javac()
+                .withProcessors(new ExtensionProcessor())
+                .compile(JavaFileObjects.forSourceString(
+                        "test.MyTestClass", sourceCode1
+                ));
+
+        Compilation compilationHasParameters = Compiler.javac()
+                .withProcessors(new ExtensionProcessor())
+                        .compile(JavaFileObjects.forSourceString(
+                                "test.MyTestClass", sourceCode2
+                        ));
+
+        Compilation compilationNotPublic = Compiler.javac()
+                .withProcessors(new ExtensionProcessor())
+                        .compile(JavaFileObjects.forSourceString(
+                            "test.MyTestClass", sourceCode3
+                        ));
+
+        Compilation compilationBadReturnType = Compiler.javac()
+                .withProcessors(new ExtensionProcessor())
+                        .compile(JavaFileObjects.forSourceString(
+                                "test.MyTestClass", sourceCode4
+                        ));
+
+        Compilation compilationNotStatic = Compiler.javac()
+                .withProcessors(new ExtensionProcessor())
+                        .compile(JavaFileObjects.forSourceString(
+                                "test.MyTestClass", sourceCode5
+                        ));
+
+        // Asserting the compilations
+        assertThat(compilationNoAnnotation).failed();
+        assertThat(compilationHasParameters).failed();
+        assertThat(compilationNotPublic).failed();
+        assertThat(compilationBadReturnType).failed();
+        assertThat(compilationNotStatic).failed();
+    }
+
+    @Test
+    public void testValidAnnotationUsage() {
+        // Valid annotated class and method
+        String sourceCode = """
+                package com.icst.blockidle.extension;
+
+                import com.icst.blockidle.Extension;
+                import com.icst.blockidle.ExtensionItem;
+
+                @Extension(extensionFileName = "MyClass") // The class is annotated with @Extension
+                public class MyClass {
+
+                    // A valid method annotated with @ExtensionItem
+                    @ExtensionItem(extensionItemName = "exampleItem")
+                    public static String myMethod() { // The method is static, has no parameters, and returns a valid type
+                        return "Hello, world!";
+                    }
+                }
+                """;
+
+        Compilation compilation = Compiler.javac()
+                .withProcessors(new ExtensionProcessor()) // Pass a new instance of your processor
+                .compile(JavaFileObjects.forSourceString(
+                        "com.icst.blockidle.extension.MyClass", sourceCode));
+
+        // Assert that the compilation succeeds
+        assertThat(compilation).succeeded();
+
+        // Optionally, check the generated source file
+        assertThat(compilation)
+                .generatedSourceFile("com.icst.blockidle.extension.MyClassExtensionOutputStream")
+                .contentsAsUtf8String()
+                .contains("package com.icst.blockidle.extension;");
+        
+        File zipFile = new File("build/generated/MyClass.extension");
+        if (!zipFile.exists()) fail();
+    }
+}

--- a/annotations-processor/src/main/java/com/icst/blockidle/ExtensionProcessorTester.java
+++ b/annotations-processor/src/main/java/com/icst/blockidle/ExtensionProcessorTester.java
@@ -191,7 +191,7 @@ public class extensionProcessorTester {
                 .contentsAsUtf8String()
                 .contains("package com.icst.blockidle.extension;");
         
-        File zipFile = new File("build/generated/MyClass.extension");
+        File zipFile = new File("BlockIDLE/extensions/build/extensions/MyClass");
         if (!zipFile.exists()) fail();
     }
 }


### PR DESCRIPTION
I made a simple way to test the ExtensionProcessor. It uses real-time compilation that let's me test the behavior of the processor really easy. I used sample classes with different problems(i.e with bad return type, class not public etc.) to see if the processor will return an error.

For the valid test, where we expect the processor to be able to successfully create the ZIP file, I made sure to check if the ZIP file got also created, like you asked me to add in the previous pull request conversation. 

**NOTE** that I am not sure if the things are configured right on the valid test method, can you pls have a look at that and change what's needed? Perhaps the ZIP File's path is not something like: `BlockIDLE/extensions/build/Extensions/MyClass.extension`. I can't know exactly how you have those stuff configured, so it is better to change those minor details and see if the unit test is good for you.

Also, if this seems a valid way for you to test the processor, I'll run some tests with my processor version, the one that seems to have problems, and see how I can make it work and perhaps remerging it again.